### PR TITLE
db_util.py: Fixing names of locus files for PubMLST

### DIFF
--- a/scripts/db_util.py
+++ b/scripts/db_util.py
@@ -151,8 +151,9 @@ def fetch_db(species, outDbDir):
         print(" Fetching allele sequences: ")
         
         # Fetch loci sequence files
-        for locusUrl in species.iterfind("./mlst/database/loci/locus/url") :
-            locusName = os.path.splitext(os.path.basename(locusUrl.text))[0]
+        for locus in species.iterfind("./mlst/database/loci/locus"):
+            locusName = locus.text.strip()
+            locusUrl = locus.find("./url")
             fileName  = os.path.join(outDbDir,locusName+".fa")
             urllib.request.urlretrieve(locusUrl.text, fileName)
             print(" - {} -> {}".format(locusUrl.text, fileName))


### PR DESCRIPTION
This fixes issue #7 by extracting the proper names for the alleles fasta files from the PubMLST API.